### PR TITLE
 Fixed verification of empty attributes saving

### DIFF
--- a/src/DataLayer.php
+++ b/src/DataLayer.php
@@ -284,7 +284,9 @@ abstract class DataLayer
         $data = (array)$this->data();
         foreach ($this->required as $field) {
             if (empty($data[$field])) {
-                return false;
+                if(!is_int($data[$field])){
+                    return false;
+                }
             }
         }
         return true;


### PR DESCRIPTION
the required () method must verify that the value being passed in the attribute is zero, otherwise, it will treat a true value, which should be used from zero as an empty attribute