### PR TITLE
Correção no retorno do Update

### DIFF
--- a/src/DataLayer.php
+++ b/src/DataLayer.php
@@ -252,7 +252,9 @@ abstract class DataLayer
             /** Update */
             if (!empty($this->data->$primary)) {
                 $id = $this->data->$primary;
-                $this->update($this->safe(), "{$this->primary} = :id", "id={$id}");
+                if(!$this->update($this->safe(), "{$this->primary} = :id", "id={$id}")) {
+                    return false;
+                }
             }
 
             /** Create */


### PR DESCRIPTION
Correção no retorno do Update possibilitando o retorno como `true `ou `false` para exibir possível mensagens de erro quando algum campo for esquecido no processo de desenvolvimento.