### PR TITLE
Tipagem incorreta

### DIFF
--- a/src/DataLayer.php
+++ b/src/DataLayer.php
@@ -41,11 +41,11 @@ abstract class DataLayer
     /** @var string|null */
     protected ?string $order = null;
 
-    /** @var int */
+    /** @var string|null */
     protected ?string $limit = null;
 
-    /** @var int */
-    protected ?int $offset = null;
+    /** @var string|null */
+    protected ?string $offset = null;
 
     /** @var PDOException|null */
     protected ?PDOException $fail = null;


### PR DESCRIPTION
correção na tipagem das variáveis $offset e $limit 
estavam com null ou int , porém o correto seria null ou string