### PR TITLE
Deleting update_at from create method

### DIFF
--- a/src/CrudTrait.php
+++ b/src/CrudTrait.php
@@ -20,7 +20,6 @@ trait CrudTrait
     {
         if ($this->timestamps) {
             $data["created_at"] = (new DateTime("now"))->format("Y-m-d H:i:s");
-            $data["updated_at"] = $data["created_at"];
         }
 
         try {


### PR DESCRIPTION
Deletes the line that updates the update_at field within the create method (of CrudTrait). For default the update_at field must be NULL until the first record update.