### PR TITLE
Corrogido o erro de parse_str usando o PHP 8.1

### DIFF
--- a/src/CrudTrait.php
+++ b/src/CrudTrait.php
@@ -57,7 +57,7 @@ trait CrudTrait
                 $dateSet[] = "{$bind} = :{$bind}";
             }
             $dateSet = implode(", ", $dateSet);
-            parse_str($params, $params);
+            parse_str((string)$params, $params);
 
             $stmt = Connect::getInstance($this->database);
             $prepare = $stmt->prepare("UPDATE {$this->entity} SET {$dateSet} WHERE {$terms}");
@@ -81,7 +81,7 @@ trait CrudTrait
             $stmt = Connect::getInstance($this->database);
             $prepare = $stmt->prepare("DELETE FROM {$this->entity} WHERE {$terms}");
             if ($params) {
-                parse_str($params, $params);
+                parse_str((string)$params, $params);
                 $prepare->execute($params);
                 return true;
             }

--- a/src/DataLayer.php
+++ b/src/DataLayer.php
@@ -152,7 +152,7 @@ abstract class DataLayer
     {
         if ($terms) {
             $this->statement = "SELECT {$columns} FROM {$this->entity} WHERE {$terms}";
-            parse_str($params, $this->params);
+            parse_str((string)$params, $this->params);
             return $this;
         }
 


### PR DESCRIPTION
pos actualizar o php 8.1, apresentou erro de parse_str, ent#ao encontrei esta solução para corrogir a possivel exceção de deprecated