### PR TITLE
Adicionar GROUP BY ao método count()

### DIFF
--- a/src/DataLayer.php
+++ b/src/DataLayer.php
@@ -231,7 +231,7 @@ abstract class DataLayer
      */
     public function count(): int
     {
-        $stmt = Connect::getInstance()->prepare($this->statement);
+        $stmt = Connect::getInstance()->prepare($this->statement . $this->group);
         $stmt->execute($this->params);
         return $stmt->rowCount();
     }


### PR DESCRIPTION
Caso seja preciso usar o método `count()` após realizar o agrupamento o valores com `GROUP BY` o retorno sempre é 1, adicionando o `$this->group` junto ao `$this->statement` é possível retornar número exato de linhas após o agrupamento.

```
public function count(): int
{
    $stmt = Connect::getInstance()->prepare($this->statement . $this->group);
    $stmt->execute($this->params);
    return $stmt->rowCount();
}
```