### PR TITLE
Deprecated: parse_str(): Passing null to parameter #1 ($string) 

### DIFF
--- a/src/DataLayer.php
+++ b/src/DataLayer.php
@@ -59,6 +59,7 @@ abstract class DataLayer
      * @param array $required
      * @param string $primary
      * @param bool $timestamps
+     * @param array|null $database
      */
     public function __construct(
         string $entity,
@@ -118,7 +119,7 @@ abstract class DataLayer
      * @param int $mode
      * @return array|null
      */
-    public function columns($mode = PDO::FETCH_OBJ): ?array
+    public function columns(int $mode = PDO::FETCH_OBJ): ?array
     {
         $stmt = Connect::getInstance($this->database)->prepare("DESCRIBE {$this->entity}");
         $stmt->execute($this->params);
@@ -152,7 +153,9 @@ abstract class DataLayer
     {
         if ($terms) {
             $this->statement = "SELECT {$columns} FROM {$this->entity} WHERE {$terms}";
-            parse_str($params, $this->params);
+            if ($params) {
+                parse_str($params, $this->params);
+            }
             return $this;
         }
 


### PR DESCRIPTION
Deprecated: parse_str(): Passing null to parameter #1 ($string) of type string is deprecated in /home/cagep529/orcacagep/vendor/coffeecode/datalayer/src/DataLayer.php on line 155

Check if the value of $param is passed to be later inserted in the str_parse function, if it is null, do not insert it, not showing the error message