### PR TITLE
Feat: Prevendo erro de inicialização em PHP^8

### DIFF
--- a/src/Connect.php
+++ b/src/Connect.php
@@ -12,7 +12,7 @@ use PDOException;
 class Connect
 {
     /** @var array */
-    private static array $instance;
+    private static array $instance = [];
 
     /** @var PDOException|null */
     private static ?PDOException $error = null;


### PR DESCRIPTION
Existe o seguinte erro: PHP Fatal error:  Uncaught Error: Typed static property CoffeeCode\DataLayer\Connect::$instance must not be accessed before initialization in /var/www/html/vendor/coffeecode/datalayer/src/Connect.php:48

Esse erro indica que a propriedade static tipada Connect::$instance da biblioteca CoffeeCode\DataLayer está sendo acessada antes de ser inicializada.

Causa
No PHP 8.1+, quando você define uma propriedade static com tipagem e sem valor padrão, ela deve ser inicializada antes de ser acessada, caso contrário ocorre um erro fatal.